### PR TITLE
Use Site Inspector to crawl the candidates domains

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,4 @@
+source "https://rubygems.org"
+
+gem 'site-inspector', :github => "benbalter/site-inspector"
+gem 'pry'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,61 @@
+GIT
+  remote: git://github.com/benbalter/site-inspector.git
+  revision: 341c7cb8e2dafbf0511e4b3995adcfa3bd1e8113
+  specs:
+    site-inspector (2.1.0)
+      colorator (~> 0.1)
+      dnsruby (~> 1.56)
+      gman (~> 4.1)
+      mercenary (~> 0.3)
+      nokogiri (~> 1.6)
+      oj (~> 2.11)
+      public_suffix (~> 1.4)
+      sniffles (~> 0.2)
+      typhoeus (~> 0.7)
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    addressable (2.3.8)
+    coderay (1.1.0)
+    colorator (0.1)
+    colorize (0.7.7)
+    dnsruby (1.58.0)
+    ethon (0.7.4)
+      ffi (>= 1.3.0)
+    ffi (1.9.10)
+    gman (4.7.1)
+      colorize (~> 0.7)
+      iso_country_codes (~> 0.6)
+      naughty_or_nice (~> 0.0.2)
+      swot (~> 0.4.2)
+    iso_country_codes (0.7.1)
+    mercenary (0.3.5)
+    method_source (0.8.2)
+    mini_portile (0.6.2)
+    naughty_or_nice (0.0.4)
+      addressable (~> 2.3)
+      public_suffix (>= 1.2)
+    nokogiri (1.6.6.2)
+      mini_portile (~> 0.6.0)
+    oj (2.12.11)
+    pry (0.10.1)
+      coderay (~> 1.1.0)
+      method_source (~> 0.8.1)
+      slop (~> 3.4)
+    public_suffix (1.5.1)
+    slop (3.6.0)
+    sniffles (0.2.0)
+      nokogiri (~> 1.6.1)
+    swot (0.4.2)
+      naughty_or_nice
+      public_suffix
+    typhoeus (0.7.3)
+      ethon (>= 0.7.4)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  pry
+  site-inspector!

--- a/candidates.csv
+++ b/candidates.csv
@@ -1,16 +1,16 @@
-candidate,party,domain,framework,open source?
-Ben Carson,R,bencarson.com,Unknown static site,?
-Bernie Sanders,D,berniesanders.com,WordPress,Y
-Chris Christie,R,chrischristie.com,Cowboy (Erlang),Y
-Donald Trump,R,donaldjtrump.com,Expression Engine,Y
-Hillary Clinton,D,hillaryclinton.com,Unknown static site,?
-Jeb Bush,R,jeb2016.com,WordPress,Y
-Jim Webb,D,webb2016.com,WordPress,Y
-John Kasich,R,johnkasich.com,WordPress,Y
-Lincoln Chafee,D,chafee2016.com,WordPress,Y
-Marco Rubio,R,marcorubio.com,WordPress,Y
-Martin O'Malley,D,martinomalley.com,WordPress,Y
-Mike Huckabee,R,mikehuckabee.com,ASP.net,N
-Rand Paul,R,randpaul.com,Unknown,?
-Scott Walker,R,scottwalker.com,Drupal,Y
-Ted Cruz,R,tedcruz.org,WordPress,Y
+candidate,party,domain,www?,non_www?,https?,enforces_https?,downgrades_https?,canonically_www?,canonically_https?,hsts?,hsts_preload?,sitemap?,robots_txt?,humans_txt?,proper_404s?,dnssec?,ipv6?,cloud_provider,google_apps?,server,cms,508_errors
+Ben Carson,R,bencarson.com,true,true,true,false,false,true,true,false,false,true,false,false,true,false,true,,false,cloudflare-nginx,,1
+Bernie Sanders,D,berniesanders.com,true,true,true,true,false,false,true,false,false,true,true,false,true,false,false,,true,cloudflare-nginx,wordpress,9
+Chris Christie,R,chrischristie.com,true,true,true,true,false,true,true,true,false,true,true,false,true,true,true,amazon,false,Cowboy,,4
+Donald Trump,R,donaldjtrump.com,true,true,true,true,false,true,true,false,false,false,true,false,true,false,true,,false,cloudflare-nginx,,8
+Hillary Clinton,D,hillaryclinton.com,true,true,true,true,false,true,true,true,false,false,true,false,true,true,true,,false,AmazonS3,,16
+Jeb Bush,R,jeb2016.com,true,true,true,false,false,false,true,false,false,true,true,false,true,false,false,,false,cloudflare-nginx,wordpress,40
+Jim Webb,D,webb2016.com,true,true,true,true,false,true,true,false,false,true,true,false,true,false,true,,false,cloudflare-nginx,,
+John Kasich,R,johnkasich.com,true,true,true,true,false,false,true,false,false,true,true,false,true,false,false,,true,Apache,wordpress,11
+Lincoln Chafee,D,chafee2016.com,true,true,true,false,false,true,false,false,false,true,true,false,true,false,false,linode,false,nginx,wordpress,9
+Marco Rubio,R,marcorubio.com,true,true,true,true,false,false,true,false,false,true,true,false,true,false,true,,true,cloudflare-nginx,wordpress,
+Martin O'Malley,D,martinomalley.com,true,true,true,false,false,false,true,false,false,true,true,false,true,false,false,linode,true,nginx,wordpress,23
+Mike Huckabee,R,mikehuckabee.com,true,true,true,true,false,false,true,false,false,false,false,false,true,false,false,,false,"",,1
+Rand Paul,R,randpaul.com,true,true,true,true,false,false,true,false,false,false,true,false,true,false,true,,true,cloudflare-nginx,,21
+Scott Walker,R,scottwalker.com,true,true,true,false,false,true,true,false,false,true,true,false,true,true,true,,false,nginx,drupal,6
+Ted Cruz,R,tedcruz.org,true,true,true,false,false,true,true,true,false,,,,false,false,true,,false,cloudflare-nginx,wordpress,20

--- a/candidates.csv
+++ b/candidates.csv
@@ -1,4 +1,4 @@
-Candidate,Party,Domain,Framework,Open Source?
+candidate,party,domain,framework,open source?
 Ben Carson,R,bencarson.com,Unknown static site,?
 Bernie Sanders,D,berniesanders.com,WordPress,Y
 Chris Christie,R,chrischristie.com,Cowboy (Erlang),Y

--- a/readme.md
+++ b/readme.md
@@ -2,10 +2,32 @@
 
 An entirely unofficial look at the technology stacks of the 2016 Presidential Campaigns
 
+## Results
+
+You can see the full results in the [`candidates.csv`](candidates.csv) file, but here's the overview:
+
+* www?: 15/15 (100.0%)
+* non_www?: 15/15 (100.0%)
+* https?: 15/15 (100.0%)
+* enforces_https?: 9/15 (60.0%)
+* downgrades_https?: 0/15 (0.0%)
+* canonically_www?: 8/15 (53.33%)
+* canonically_https?: 14/15 (93.33%)
+* hsts?: 3/15 (20.0%)
+* hsts_preload?: 0/15 (0.0%)
+* sitemap?: 10/15 (66.67%)
+* robots_txt?: 12/15 (80.0%)
+* humans_txt?: 0/15 (0.0%)
+* proper_404s?: 14/15 (93.33%)
+* dnssec?: 3/15 (20.0%)
+* ipv6?: 9/15 (60.0%)
+* google_apps?: 5/15 (33.33%)
+* open_source?: 8/15 (53.33%) (my human-powered guess is actually 12+/15)
+
 ## How the data is gathered
 
-By looking at site source code, cookies, and server headers, in the future, augmented by [site inspector](https://github.com/benbalter/site-inspector).
+[Site Inspector](https://github.com/benbalter/site-inspector).
 
 ## Is it accurate?
 
-Your guess is as good as mine. Use at your own peril. 
+Your guess is as good as mine. Use at your own peril.

--- a/script/bootstrap
+++ b/script/bootstrap
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+set -ex
+
+bundle install

--- a/script/console
+++ b/script/console
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+bundle exec pry -r 'site-inspector'

--- a/script/crawl
+++ b/script/crawl
@@ -1,0 +1,66 @@
+#! /usr/bin/env ruby
+
+require 'csv'
+require 'site-inspector'
+
+output = []
+csv = File.expand_path "../candidates.csv", File.dirname(__FILE__)
+candidates = CSV.read(csv, :headers => true)
+
+candidates.each do |candidate|
+  domain = candidate["domain"]
+  inspector = SiteInspector.inspect domain
+  inspector.prefetch
+
+  # simplify the CMS-sniffing output
+  cms = inspector.canonical_endpoint.sniffer.cms
+  cms = cms.keys.first if cms
+
+  output.push({
+    :candidate          => candidate["candidate"],
+    :party              => candidate["party"],
+    :domain             => inspector.host,
+    :www?               => inspector.www?,
+    :non_www?           => inspector.root?,
+    :https?             => inspector.https?,
+    :enforces_https?    => inspector.enforces_https?,
+    :downgrades_https?  => inspector.downgrades_https?,
+    :canonically_www?   => inspector.canonically_www?,
+    :canonically_https? => inspector.canonically_https?,
+    :hsts?              => inspector.hsts?,
+    :hsts_preload?      => inspector.canonical_endpoint.hsts.preload?,
+    :sitemap?           => inspector.canonical_endpoint.content.sitemap_xml?,
+    :robots_txt?        => inspector.canonical_endpoint.content.robots_txt?,
+    :humans_txt?        => inspector.canonical_endpoint.content.humans_txt?,
+    :proper_404s?       => inspector.canonical_endpoint.content.proper_404s?,
+    :dnssec?            => inspector.canonical_endpoint.dns.dnssec?,
+    :ipv6?              => inspector.canonical_endpoint.dns.ipv6?,
+    :cloud_provider     => inspector.canonical_endpoint.dns.cloud_provider,
+    :google_apps?       => inspector.canonical_endpoint.dns.google_apps?,
+    :server             => inspector.canonical_endpoint.headers.server,
+    :cms                => cms,
+    :"508_errors"       => inspector.canonical_endpoint.accessibility.errors
+  })
+end
+
+headings = output.first.keys
+CSV.open(csv, "wb") do |csv|
+  csv << headings
+  output.each do |row|
+    csv << row.values
+  end
+end
+
+def output_check(check, count, candidates)
+  percent = (100 * count.to_f/candidates.count.to_f).round(2)
+  puts "#{check}: #{count}/#{candidates.count} (#{percent}%)"
+end
+
+headings.each do |check|
+  next unless check =~ /\?$/
+  count = output.map { |r| r[check] }.count { |value| value }
+  output_check(check, count, candidates)
+end
+
+count = output.map { |r| r[:cms] }.count { |value| [:wordpress, :drupal].include?(value) }
+output_check("open_source?", count, candidates)


### PR DESCRIPTION
The initial results:
- www?: 15/15 (100.0%)
- non_www?: 15/15 (100.0%)
- https?: 15/15 (100.0%)
- enforces_https?: 9/15 (60.0%)
- downgrades_https?: 0/15 (0.0%)
- canonically_www?: 8/15 (53.33%)
- canonically_https?: 14/15 (93.33%)
- hsts?: 3/15 (20.0%)
- hsts_preload?: 0/15 (0.0%)
- sitemap?: 10/15 (66.67%)
- robots_txt?: 12/15 (80.0%)
- humans_txt?: 0/15 (0.0%)
- proper_404s?: 14/15 (93.33%)
- dnssec?: 3/15 (20.0%)
- ipv6?: 9/15 (60.0%)
- google_apps?: 5/15 (33.33%)
- open_source?: 8/15 (53.33%) (my human-powered guess is actually 12+/15)

/cc @konklone because 100% HTTPS, 20% HSTS, 60% HTTPS enforced, 20% DNSSEC, 60% IPv6, and 93% canonical HTTPS

/cc @adelevie because pa11y stats in the CSV
