### PR TITLE
Make crawler more oo

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,7 @@
 source "https://rubygems.org"
 
 gem 'site-inspector', :github => "benbalter/site-inspector"
+gem 'terminal-table'
+gem 'parallel'
+gem 'ruby-progressbar'
 gem 'pry'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -39,17 +39,20 @@ GEM
     nokogiri (1.6.6.2)
       mini_portile (~> 0.6.0)
     oj (2.12.11)
+    parallel (1.6.0)
     pry (0.10.1)
       coderay (~> 1.1.0)
       method_source (~> 0.8.1)
       slop (~> 3.4)
     public_suffix (1.5.1)
+    ruby-progressbar (1.7.5)
     slop (3.6.0)
     sniffles (0.2.0)
       nokogiri (~> 1.6.1)
     swot (0.4.2)
       naughty_or_nice
       public_suffix
+    terminal-table (1.4.5)
     typhoeus (0.7.3)
       ethon (>= 0.7.4)
 
@@ -57,5 +60,8 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  parallel
   pry
+  ruby-progressbar
   site-inspector!
+  terminal-table

--- a/candidates.csv
+++ b/candidates.csv
@@ -1,16 +1,16 @@
-candidate,party,domain,www?,non_www?,https?,enforces_https?,downgrades_https?,canonically_www?,canonically_https?,hsts?,hsts_preload?,sitemap?,robots_txt?,humans_txt?,proper_404s?,dnssec?,ipv6?,cloud_provider,google_apps?,server,cms,508_errors
-Ben Carson,R,bencarson.com,true,true,true,false,false,true,true,false,false,true,false,false,true,false,true,,false,cloudflare-nginx,,1
-Bernie Sanders,D,berniesanders.com,true,true,true,true,false,false,true,false,false,true,true,false,true,false,false,,true,cloudflare-nginx,wordpress,9
-Chris Christie,R,chrischristie.com,true,true,true,true,false,true,true,true,false,true,true,false,true,true,true,amazon,false,Cowboy,,4
-Donald Trump,R,donaldjtrump.com,true,true,true,true,false,true,true,false,false,false,true,false,true,false,true,,false,cloudflare-nginx,,8
-Hillary Clinton,D,hillaryclinton.com,true,true,true,true,false,true,true,true,false,false,true,false,true,true,true,,false,AmazonS3,,16
-Jeb Bush,R,jeb2016.com,true,true,true,false,false,false,true,false,false,true,true,false,true,false,false,,false,cloudflare-nginx,wordpress,40
-Jim Webb,D,webb2016.com,true,true,true,true,false,true,true,false,false,true,true,false,true,false,true,,false,cloudflare-nginx,,
-John Kasich,R,johnkasich.com,true,true,true,true,false,false,true,false,false,true,true,false,true,false,false,,true,Apache,wordpress,11
-Lincoln Chafee,D,chafee2016.com,true,true,true,false,false,true,false,false,false,true,true,false,true,false,false,linode,false,nginx,wordpress,9
-Marco Rubio,R,marcorubio.com,true,true,true,true,false,false,true,false,false,true,true,false,true,false,true,,true,cloudflare-nginx,wordpress,
-Martin O'Malley,D,martinomalley.com,true,true,true,false,false,false,true,false,false,true,true,false,true,false,false,linode,true,nginx,wordpress,23
-Mike Huckabee,R,mikehuckabee.com,true,true,true,true,false,false,true,false,false,false,false,false,true,false,false,,false,"",,1
-Rand Paul,R,randpaul.com,true,true,true,true,false,false,true,false,false,false,true,false,true,false,true,,true,cloudflare-nginx,,21
-Scott Walker,R,scottwalker.com,true,true,true,false,false,true,true,false,false,true,true,false,true,true,true,,false,nginx,drupal,6
-Ted Cruz,R,tedcruz.org,true,true,true,false,false,true,true,true,false,,,,false,false,true,,false,cloudflare-nginx,wordpress,20
+name,party,domain,www?,non_www?,https?,enforces_https?,downgrades_https?,canonically_www?,canonically_https?,hsts?,hsts_preload?,sitemap?,robots_txt?,humans_txt?,proper_404s?,dnssec?,ipv6?,cloud_provider,google_apps?,server,open_source?,cms,508_errors
+Ben Carson,R,bencarson.com,true,true,true,false,false,true,true,false,false,true,false,false,true,false,true,,false,cloudflare-nginx,,,
+Bernie Sanders,D,berniesanders.com,true,true,true,true,false,false,true,false,false,true,true,false,true,false,false,,true,cloudflare-nginx,true,wordpress,9
+Chris Christie,R,chrischristie.com,true,true,true,true,false,true,true,true,false,true,true,false,true,true,true,amazon,false,Cowboy,true,,4
+Donald Trump,R,donaldjtrump.com,true,true,true,true,false,true,true,false,false,false,true,false,true,false,true,,false,cloudflare-nginx,,,8
+Hillary Clinton,D,hillaryclinton.com,true,true,true,true,false,true,true,true,false,false,true,false,true,true,true,,false,AmazonS3,,,16
+Jeb Bush,R,jeb2016.com,true,true,true,true,false,false,true,false,false,,,,false,false,false,amazon,false,Apache/2.4.7 (Ubuntu),,,
+Jim Webb,D,webb2016.com,true,true,true,true,false,true,true,false,false,true,true,false,true,true,true,,false,cloudflare-nginx,,,
+John Kasich,R,johnkasich.com,true,true,true,true,false,false,true,false,false,true,true,false,true,false,false,,true,Apache,true,wordpress,11
+Lincoln Chafee,D,chafee2016.com,true,true,true,false,false,true,false,false,false,true,true,false,true,false,false,linode,false,nginx,true,wordpress,9
+Marco Rubio,R,marcorubio.com,true,true,true,true,false,false,true,false,false,true,true,false,true,false,true,,true,cloudflare-nginx,true,wordpress,
+Martin O'Malley,D,martinomalley.com,true,true,true,false,false,false,true,false,false,true,true,false,true,false,false,linode,true,nginx,true,wordpress,23
+Mike Huckabee,R,mikehuckabee.com,true,true,true,true,false,false,true,false,false,false,false,false,true,false,false,,false,"",,,
+Rand Paul,R,randpaul.com,true,true,true,true,false,false,true,false,false,false,true,false,true,false,true,,true,cloudflare-nginx,,,21
+Scott Walker,R,scottwalker.com,true,true,true,false,false,true,true,false,false,true,true,false,true,true,true,,false,nginx,true,drupal,6
+Ted Cruz,R,tedcruz.org,true,true,true,false,false,true,true,true,false,,,,false,false,true,,false,cloudflare-nginx,true,wordpress,

--- a/lib/campaign_tech.rb
+++ b/lib/campaign_tech.rb
@@ -1,0 +1,106 @@
+require 'csv'
+require 'logger'
+require 'parallel'
+require 'site-inspector'
+require 'terminal-table'
+require_relative "./campaign_tech/candidate"
+
+class CampaignTech
+
+  def candidates
+    @candidates ||= candidates_from_csv.map do |candidate|
+      Candidate.new({
+        :name   => candidate["name"],
+        :domain => candidate["domain"],
+        :party  => candidate["party"]
+      })
+    end
+  end
+
+  def republicans
+    candidates_by_party("R")
+  end
+
+  def democrats
+    candidates_by_party("D")
+  end
+
+  def crawl
+    Parallel.each(candidates, :progress => "Crawling", :in_threads => 2) do |candidate|
+      candidate.crawl
+    end
+    candidates
+  end
+
+  def overview
+    options = {
+      :headings => ["Check", "Overall", "Republicans", "Democrats"],
+      :style    => { :border_i => "|" },
+    }
+    Terminal::Table.new(options) do |table|
+      headings.each do |check|
+        next unless check =~ /\?$/
+        table.add_row count_row(check)
+      end
+      table.add_row average_row(:"508_errors")
+    end.to_s.split("\n")[1...-1].join("\n")
+  end
+
+  def write_to_csv
+    CSV.open(csv, "wb") do |csv|
+      csv << headings
+      crawl.each do |candidate|
+        csv << candidate.crawl.values
+      end
+    end
+  end
+
+  private
+
+  def headings
+    @headings ||= candidates.first.crawl.keys
+  end
+
+  def csv
+    @csv ||= File.expand_path "../candidates.csv", File.dirname(__FILE__)
+  end
+
+  def candidates_by_party(party)
+    candidates.select { |c| c.party == party }
+  end
+
+  def candidates_from_csv
+    CSV.read(csv, :headers => true)
+  end
+
+  # Returns the number of candidates where value of key is truthy
+  def count(candidates, key)
+    candidates.select { |c| c.crawl[key] }.count
+  end
+
+  def average(candidates, key)
+    candidates = candidates.map { |c| c.crawl[key] }.compact
+    candidates.inject{ |sum, el| sum + el }.to_f / candidates.count.to_f
+  end
+
+  def format_fraction(numerator, denominator)
+    percent = (100 * numerator.to_f / denominator.to_f).round(2)
+    "#{numerator}/#{denominator} (#{percent}%)"
+  end
+
+  def count_row(check)
+    output = [check]
+    [candidates, republicans, democrats].each do |group|
+      output.push format_fraction(count(group, check), group.count)
+    end
+    output
+  end
+
+  def average_row(check)
+    output = ["#{check} (avg)"]
+    [candidates, republicans, democrats].each do |group|
+      output.push average(group, check).round(2)
+    end
+    output
+  end
+end

--- a/lib/campaign_tech/candidate.rb
+++ b/lib/campaign_tech/candidate.rb
@@ -1,0 +1,97 @@
+class CampaignTech
+  class Candidate
+
+    attr_reader :name, :domain, :party
+
+    def initialize(hash)
+      @name   = hash[:name]
+      @domain = hash[:domain]
+      @party  = hash[:party].upcase
+    end
+
+    def inspector
+      @inspector||= SiteInspector.inspect domain
+    end
+
+    def republican?
+      party == "R"
+    end
+
+    def democrat?
+      party == "D"
+    end
+
+    def crawl
+      @crawl ||= crawl!
+    end
+
+    def inspect
+      "#<CampaignTech::Candidate name=\"#{name}\">"
+    end
+
+    # Simplified CMS reporting
+    def cms
+      @cms ||= begin
+        cms = inspector.canonical_endpoint.sniffer.cms
+        cms.keys.first if cms
+      end
+    end
+
+    def open_source?
+      return true if [:wordpress, :drupal].include?(cms)
+      return true if inspector.canonical_endpoint.headers.server == "Cowboy"
+      nil
+    end
+
+    def method_missing(method_sym, *arguments, &block)
+      if crawl.keys.any? { |key| key == method_sym }
+        crawl[method_sym]
+      else
+        super
+      end
+    end
+
+    def respond_to?(method_sym, include_private = false)
+      if crawl.keys.any? { |key| key == method_sym }
+        true
+      else
+        super
+      end
+    end
+
+    private
+
+    def crawl!
+
+      #Speed up crawl by prefetching potential endpoints in parallel
+      inspector.prefetch
+
+      {
+        :name               => name,
+        :party              => party,
+        :domain             => inspector.host,
+        :www?               => inspector.www?,
+        :non_www?           => inspector.root?,
+        :https?             => inspector.https?,
+        :enforces_https?    => inspector.enforces_https?,
+        :downgrades_https?  => inspector.downgrades_https?,
+        :canonically_www?   => inspector.canonically_www?,
+        :canonically_https? => inspector.canonically_https?,
+        :hsts?              => inspector.hsts?,
+        :hsts_preload?      => inspector.canonical_endpoint.hsts.preload?,
+        :sitemap?           => inspector.canonical_endpoint.content.sitemap_xml?,
+        :robots_txt?        => inspector.canonical_endpoint.content.robots_txt?,
+        :humans_txt?        => inspector.canonical_endpoint.content.humans_txt?,
+        :proper_404s?       => inspector.canonical_endpoint.content.proper_404s?,
+        :dnssec?            => inspector.canonical_endpoint.dns.dnssec?,
+        :ipv6?              => inspector.canonical_endpoint.dns.ipv6?,
+        :cloud_provider     => inspector.canonical_endpoint.dns.cloud_provider,
+        :google_apps?       => inspector.canonical_endpoint.dns.google_apps?,
+        :server             => inspector.canonical_endpoint.headers.server,
+        :open_source?       => open_source?,
+        :cms                => cms,
+        :"508_errors"       => inspector.canonical_endpoint.accessibility.errors
+      }
+    end
+  end
+end

--- a/readme.md
+++ b/readme.md
@@ -6,23 +6,26 @@ An entirely unofficial look at the technology stacks of the 2016 Presidential Ca
 
 You can see the full results in the [`candidates.csv`](candidates.csv) file, but here's the overview:
 
-* www?: 15/15 (100.0%)
-* non_www?: 15/15 (100.0%)
-* https?: 15/15 (100.0%)
-* enforces_https?: 9/15 (60.0%)
-* downgrades_https?: 0/15 (0.0%)
-* canonically_www?: 8/15 (53.33%)
-* canonically_https?: 14/15 (93.33%)
-* hsts?: 3/15 (20.0%)
-* hsts_preload?: 0/15 (0.0%)
-* sitemap?: 10/15 (66.67%)
-* robots_txt?: 12/15 (80.0%)
-* humans_txt?: 0/15 (0.0%)
-* proper_404s?: 14/15 (93.33%)
-* dnssec?: 3/15 (20.0%)
-* ipv6?: 9/15 (60.0%)
-* google_apps?: 5/15 (33.33%)
-* open_source?: 8/15 (53.33%) (my human-powered guess is actually 12+/15)
+| Check              | Overall        | Republicans    | Democrats    |
+|:-------------------|:---------------|:---------------|:-------------|
+| www?               | 15/15 (100.0%) | 10/10 (100.0%) | 5/5 (100.0%) |
+| non_www?           | 15/15 (100.0%) | 10/10 (100.0%) | 5/5 (100.0%) |
+| https?             | 15/15 (100.0%) | 10/10 (100.0%) | 5/5 (100.0%) |
+| enforces_https?    | 10/15 (66.67%) | 7/10 (70.0%)   | 3/5 (60.0%)  |
+| downgrades_https?  | 0/15 (0.0%)    | 0/10 (0.0%)    | 0/5 (0.0%)   |
+| canonically_www?   | 8/15 (53.33%)  | 5/10 (50.0%)   | 3/5 (60.0%)  |
+| canonically_https? | 14/15 (93.33%) | 10/10 (100.0%) | 4/5 (80.0%)  |
+| hsts?              | 3/15 (20.0%)   | 2/10 (20.0%)   | 1/5 (20.0%)  |
+| hsts_preload?      | 0/15 (0.0%)    | 0/10 (0.0%)    | 0/5 (0.0%)   |
+| sitemap?           | 9/15 (60.0%)   | 5/10 (50.0%)   | 4/5 (80.0%)  |
+| robots_txt?        | 11/15 (73.33%) | 6/10 (60.0%)   | 5/5 (100.0%) |
+| humans_txt?        | 0/15 (0.0%)    | 0/10 (0.0%)    | 0/5 (0.0%)   |
+| proper_404s?       | 13/15 (86.67%) | 8/10 (80.0%)   | 5/5 (100.0%) |
+| dnssec?            | 4/15 (26.67%)  | 2/10 (20.0%)   | 2/5 (40.0%)  |
+| ipv6?              | 9/15 (60.0%)   | 7/10 (70.0%)   | 2/5 (40.0%)  |
+| google_apps?       | 5/15 (33.33%)  | 3/10 (30.0%)   | 2/5 (40.0%)  |
+| open_source?       | 8/15 (53.33%)  | 5/10 (50.0%)   | 3/5 (60.0%)  |
+| 508_errors (avg)   | 11.89          | 10.0           | 14.25        |
 
 ## How the data is gathered
 

--- a/script/console
+++ b/script/console
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-bundle exec pry -r 'site-inspector'
+bundle exec pry -r './lib/campaign_tech'

--- a/script/crawl
+++ b/script/crawl
@@ -1,66 +1,16 @@
 #! /usr/bin/env ruby
 
-require 'csv'
-require 'site-inspector'
+require_relative "../lib/campaign_tech"
 
-output = []
-csv = File.expand_path "../candidates.csv", File.dirname(__FILE__)
-candidates = CSV.read(csv, :headers => true)
+logger = Logger.new(STDOUT)
+crawler = CampaignTech.new
 
-candidates.each do |candidate|
-  domain = candidate["domain"]
-  inspector = SiteInspector.inspect domain
-  inspector.prefetch
+logger.info "Starting crawl..."
+crawler.crawl
+logger.info "Crawl complete."
 
-  # simplify the CMS-sniffing output
-  cms = inspector.canonical_endpoint.sniffer.cms
-  cms = cms.keys.first if cms
+logger.info "Updating CSV..."
+crawler.write_to_csv
 
-  output.push({
-    :candidate          => candidate["candidate"],
-    :party              => candidate["party"],
-    :domain             => inspector.host,
-    :www?               => inspector.www?,
-    :non_www?           => inspector.root?,
-    :https?             => inspector.https?,
-    :enforces_https?    => inspector.enforces_https?,
-    :downgrades_https?  => inspector.downgrades_https?,
-    :canonically_www?   => inspector.canonically_www?,
-    :canonically_https? => inspector.canonically_https?,
-    :hsts?              => inspector.hsts?,
-    :hsts_preload?      => inspector.canonical_endpoint.hsts.preload?,
-    :sitemap?           => inspector.canonical_endpoint.content.sitemap_xml?,
-    :robots_txt?        => inspector.canonical_endpoint.content.robots_txt?,
-    :humans_txt?        => inspector.canonical_endpoint.content.humans_txt?,
-    :proper_404s?       => inspector.canonical_endpoint.content.proper_404s?,
-    :dnssec?            => inspector.canonical_endpoint.dns.dnssec?,
-    :ipv6?              => inspector.canonical_endpoint.dns.ipv6?,
-    :cloud_provider     => inspector.canonical_endpoint.dns.cloud_provider,
-    :google_apps?       => inspector.canonical_endpoint.dns.google_apps?,
-    :server             => inspector.canonical_endpoint.headers.server,
-    :cms                => cms,
-    :"508_errors"       => inspector.canonical_endpoint.accessibility.errors
-  })
-end
-
-headings = output.first.keys
-CSV.open(csv, "wb") do |csv|
-  csv << headings
-  output.each do |row|
-    csv << row.values
-  end
-end
-
-def output_check(check, count, candidates)
-  percent = (100 * count.to_f/candidates.count.to_f).round(2)
-  puts "#{check}: #{count}/#{candidates.count} (#{percent}%)"
-end
-
-headings.each do |check|
-  next unless check =~ /\?$/
-  count = output.map { |r| r[check] }.count { |value| value }
-  output_check(check, count, candidates)
-end
-
-count = output.map { |r| r[:cms] }.count { |value| [:wordpress, :drupal].include?(value) }
-output_check("open_source?", count, candidates)
+logger.info "Fin."
+puts crawler.overview


### PR DESCRIPTION
A quick rewrite to make the crawler a bit more object oriented. This allows us to break down results by party.

The new results:

| Check | Overall | Republicans | Democrats |
| :-- | :-- | :-- | :-- |
| www? | 15/15 (100.0%) | 10/10 (100.0%) | 5/5 (100.0%) |
| non_www? | 15/15 (100.0%) | 10/10 (100.0%) | 5/5 (100.0%) |
| https? | 15/15 (100.0%) | 10/10 (100.0%) | 5/5 (100.0%) |
| enforces_https? | 10/15 (66.67%) | 7/10 (70.0%) | 3/5 (60.0%) |
| downgrades_https? | 0/15 (0.0%) | 0/10 (0.0%) | 0/5 (0.0%) |
| canonically_www? | 8/15 (53.33%) | 5/10 (50.0%) | 3/5 (60.0%) |
| canonically_https? | 14/15 (93.33%) | 10/10 (100.0%) | 4/5 (80.0%) |
| hsts? | 3/15 (20.0%) | 2/10 (20.0%) | 1/5 (20.0%) |
| hsts_preload? | 0/15 (0.0%) | 0/10 (0.0%) | 0/5 (0.0%) |
| sitemap? | 9/15 (60.0%) | 5/10 (50.0%) | 4/5 (80.0%) |
| robots_txt? | 11/15 (73.33%) | 6/10 (60.0%) | 5/5 (100.0%) |
| humans_txt? | 0/15 (0.0%) | 0/10 (0.0%) | 0/5 (0.0%) |
| proper_404s? | 13/15 (86.67%) | 8/10 (80.0%) | 5/5 (100.0%) |
| dnssec? | 4/15 (26.67%) | 2/10 (20.0%) | 2/5 (40.0%) |
| ipv6? | 9/15 (60.0%) | 7/10 (70.0%) | 2/5 (40.0%) |
| google_apps? | 5/15 (33.33%) | 3/10 (30.0%) | 2/5 (40.0%) |
| open_source? | 8/15 (53.33%) | 5/10 (50.0%) | 3/5 (60.0%) |
| 508_errors (avg) | 11.89 | 10.0 | 14.25 |
